### PR TITLE
nightly clippy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: nightly
           override: true
       - run: rustup component add clippy
       - uses: actions-rs/cargo@v1


### PR DESCRIPTION
- Use sha-1 crate instead of slower sha1
- Use more references
- Add test
- Use nightly toolchain for Clippy
